### PR TITLE
Makefile: centralize bin + add cross-platform new-exercise scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI - Make build & smoke tests
+
+on:
+  push:
+    branches: [ main, fix/makefile-new-script ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build essentials
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential make gcc
+      - name: Make - new + build
+        run: |
+          make -B new PROG=exci
+          make
+      - name: Run smoke test
+        run: |
+          if [ -x ./bin/exci ]; then ./bin/exci; else echo "bin/exci missing"; exit 1; fi
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install MSYS2 and make
+        shell: powershell
+        run: |
+          choco install -y msys2
+          refreshenv
+          $env:PATH = "C:\\tools\\msys64\\usr\\bin;" + $env:PATH
+      - name: Ensure gcc and make available
+        shell: bash
+        run: |
+          pacman -Syu --noconfirm || true
+          pacman -S --noconfirm base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-make
+      - name: Make - new + build (MSYS)
+        shell: bash
+        run: |
+          make -B new PROG=exci
+          make
+      - name: Run smoke test
+        shell: bash
+        run: |
+          if [ -x ./bin/exci ]; then ./bin/exci; else echo "bin/exci missing"; exit 1; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,17 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y build-essential make gcc
       - name: Make - new + build
+        env:
+          SMOKE_PROG: ex${{ (github.run_id % 90) + 11 }}
         run: |
-          make -B new PROG=exci
+          echo "Using smoke prog: $SMOKE_PROG"
+          make -B new PROG=$SMOKE_PROG
           make
       - name: Run smoke test
+        env:
+          SMOKE_PROG: ex${{ (github.run_id % 90) + 11 }}
         run: |
-          if [ -x ./bin/exci ]; then ./bin/exci; else echo "bin/exci missing"; exit 1; fi
+          if [ -x ./bin/$SMOKE_PROG ]; then ./bin/$SMOKE_PROG; else echo "bin/$SMOKE_PROG missing"; exit 1; fi
 
   build-windows:
     runs-on: windows-latest
@@ -40,10 +45,15 @@ jobs:
           pacman -S --noconfirm base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-make
       - name: Make - new + build (MSYS)
         shell: bash
+        env:
+          SMOKE_PROG: ex${{ (github.run_id % 90) + 11 }}
         run: |
-          make -B new PROG=exci
+          echo "Using smoke prog: $SMOKE_PROG"
+          make -B new PROG=$SMOKE_PROG
           make
       - name: Run smoke test
         shell: bash
+        env:
+          SMOKE_PROG: ex${{ (github.run_id % 90) + 11 }}
         run: |
-          if [ -x ./bin/exci ]; then ./bin/exci; else echo "bin/exci missing"; exit 1; fi
+          if [ -x ./bin/$SMOKE_PROG ]; then ./bin/$SMOKE_PROG; else echo "bin/$SMOKE_PROG missing"; exit 1; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,24 @@ jobs:
           sudo apt-get install -y build-essential make gcc
       - name: Make - new + build
         env:
-          SMOKE_PROG: ex${{ (github.run_id % 90) + 11 }}
+          # SMOKE_PROG will be injected by the previous step via GITHUB_ENV
+          SMOKE_PROG: ${{ env.SMOKE_PROG }}
         run: |
           echo "Using smoke prog: $SMOKE_PROG"
           make -B new PROG=$SMOKE_PROG
           make
       - name: Run smoke test
         env:
-          SMOKE_PROG: ex${{ (github.run_id % 90) + 11 }}
+          SMOKE_PROG: ${{ env.SMOKE_PROG }}
         run: |
           if [ -x ./bin/$SMOKE_PROG ]; then ./bin/$SMOKE_PROG; else echo "bin/$SMOKE_PROG missing"; exit 1; fi
+      - name: Setup smoke prog
+        if: always()
+        run: |
+          # compute a reasonably-sized index from run id and write to file
+          IDX=$(( ${GITHUB_RUN_ID:-$RANDOM} % 90 + 11 ))
+          SMOKE="ex$(printf "%02d" $IDX)"
+          echo "SMOKE_PROG=$SMOKE" >> $GITHUB_ENV
 
   build-windows:
     runs-on: windows-latest
@@ -43,10 +51,17 @@ jobs:
         run: |
           pacman -Syu --noconfirm || true
           pacman -S --noconfirm base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-make
+      - name: Setup smoke prog
+        if: always()
+        shell: bash
+        run: |
+          IDX=$(( ${GITHUB_RUN_ID:-$RANDOM} % 90 + 11 ))
+          SMOKE="ex$(printf "%02d" $IDX)"
+          echo "SMOKE_PROG=$SMOKE" >> $GITHUB_ENV
       - name: Make - new + build (MSYS)
         shell: bash
         env:
-          SMOKE_PROG: ex${{ (github.run_id % 90) + 11 }}
+          SMOKE_PROG: ${{ env.SMOKE_PROG }}
         run: |
           echo "Using smoke prog: $SMOKE_PROG"
           make -B new PROG=$SMOKE_PROG
@@ -54,6 +69,14 @@ jobs:
       - name: Run smoke test
         shell: bash
         env:
-          SMOKE_PROG: ex${{ (github.run_id % 90) + 11 }}
+          SMOKE_PROG: ${{ env.SMOKE_PROG }}
         run: |
           if [ -x ./bin/$SMOKE_PROG ]; then ./bin/$SMOKE_PROG; else echo "bin/$SMOKE_PROG missing"; exit 1; fi
+
+      - name: Setup smoke prog
+        if: always()
+        run: |
+          # compute a reasonably-sized index from run id and write to file
+          IDX=$(( ${GITHUB_RUN_ID:-$RANDOM} % 90 + 11 ))
+          SMOKE="ex$(printf "%02d" $IDX)"
+          echo "SMOKE_PROG=$SMOKE" >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ ex[0-9][0-9][0-9]
 
 # Backup
 *.bak
+
+# Ignorar executáveis gerados dentro de pastas de exercício (exemplo: Ex02_Media/ex002)
+Ex*/ex*

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,15 @@ CC = gcc
 CFLAGS = -std=c17 -Wall -Wextra -g
 BIN_DIR = bin
 
-EXER_DIRS = $(wildcard Ex[0-9][0-9]_*)
+EXER_DIRS = $(wildcard Ex[0-9][0-9]_* )
 
-.PHONY: all clean list run help
+.PHONY: all clean list run help new
 
 all:
 	@mkdir -p $(BIN_DIR)
 	@for dir in $(EXER_DIRS); do \
-		num=$$(echo $$dir | sed 's/Ex\([0-9][0-9]\)_.*/\1/'); \
-		echo "Compilando $$dir..."; \
+		num=$$(basename $$dir | sed 's/Ex\([0-9][0-9]\)_.*/\1/'); \
+		printf "Compilando %s...\n" $$dir; \
 		$(CC) $(CFLAGS) $$dir/main.c -o $(BIN_DIR)/ex$$num && chmod +x $(BIN_DIR)/ex$$num; \
 	done
 
@@ -20,12 +20,12 @@ run:
 		echo "Exercícios:"; make list; \
 		exit 1; \
 	fi; \
-	$(BIN_DIR)/$(PROG)
+	@$(BIN_DIR)/$(PROG)
 
 list:
 	@for dir in $(EXER_DIRS); do \
-		num=$$(echo $$dir | sed 's/Ex\([0-9][0-9]\)_.*/\1/'); \
-		echo "  ex$$num ($$dir)"; \
+		num=$$(basename $$dir | sed 's/Ex\([0-9][0-9]\)_.*/\1/'); \
+		printf "  ex%02d (%s)\n" $$num $$dir; \
 	done
 
 clean:
@@ -36,3 +36,20 @@ help:
 	@echo "make run PROG=ex01 - executa"
 	@echo "make list    - lista exercícios"
 	@echo "make clean   - limpa binários"
+
+# Cria novo exercício: usa shell POSIX ou PowerShell quando disponível
+new:
+	@if [ -z "$(PROG)" ]; then \
+		echo "Use: make new PROG=ex11"; \
+		exit 1; \
+	fi; \
+	@if command -v sh >/dev/null 2>&1; then \
+		sh ./scripts/create_exercise.sh $(PROG); \
+	elif command -v pwsh >/dev/null 2>&1; then \
+		pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/create_exercise.ps1 -Prog $(PROG); \
+	elif command -v powershell >/dev/null 2>&1; then \
+		powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/create_exercise.ps1 -Prog $(PROG); \
+	else \
+		echo "Nenhum shell compatível encontrado. Instale sh (Linux/WSL) ou PowerShell."; \
+		exit 1; \
+	fi

--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ Ex03_ParOuImpar/    ← Exercício 3 (verifica par ou ímpar)
    make list
    ```
 
+   ### ➕ Criar um novo exercício
+
+   Você pode criar um esqueleto de exercício (exNN) com o alvo `new` do Makefile. O Make detecta automaticamente um shell POSIX (sh) ou PowerShell e usa o script apropriado:
+
+   ```bash
+   make new PROG=ex11   # cria a pasta Ex11_New com template
+   ```
+
+   Notas de compatibilidade:
+   - Em Linux/macOS/Codespaces o `make` usa o script POSIX `scripts/create_exercise.sh`.
+   - No Windows (VS Code ou Visual Studio) o Make irá preferir PowerShell (`scripts/create_exercise.ps1`) se disponível. No Windows sem PowerShell/WSL instale `make` e um shell compatível (ex: mingw, MSYS2 ou WSL).
+
+   Com isso, o repositório funciona em:
+   - GitHub Codespaces (Linux) — totalmente suportado
+   - VS Code Desktop (Linux/macOS/Windows) — com terminal adequado
+   - Visual Studio 2022 — use a integração CMake ou WSL para compilar/debugar facilmente
+
+
 **Para depurar (F5):**
 - Pressione `F5`
 - Escolha "Debug - Escolher exercício"

--- a/scripts/create_exercise.ps1
+++ b/scripts/create_exercise.ps1
@@ -1,0 +1,41 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Prog
+)
+
+# Espera Prog no formato exNN (ex01, ex12, ...)
+if ($Prog -notmatch '^ex[0-9]{2}$') {
+    Write-Error "Formato inválido. Use: exNN (por exemplo: ex11)"
+    exit 1
+}
+
+$num = $Prog.Substring(2,2)
+$dir = "Ex${num}_New"
+
+if (-Not (Test-Path $dir)) {
+    New-Item -ItemType Directory -Path $dir | Out-Null
+}
+
+$cfile = Join-Path $dir "$Prog.c"
+$mainfile = Join-Path $dir "main.c"
+
+@"
+#include <stdio.h>
+#include "$Prog.c"
+
+int main(void) {
+    printf("Exercício criado\n");
+    return 0;
+}
+"@ | Out-File -Encoding utf8 $mainfile
+
+@"
+// Exemplo simples para $Prog
+#include <stdio.h>
+
+void ${Prog}_func(void) {
+    printf("Função de exemplo\n");
+}
+"@ | Out-File -Encoding utf8 $cfile
+
+Write-Output "$dir criado"

--- a/scripts/create_exercise.sh
+++ b/scripts/create_exercise.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env sh
+# Script simples e portátil para criar um novo exercício
+set -eu
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PROG="${1:-}"
+
+if [ -z "$PROG" ]; then
+  echo "Usage: $0 exNN" >&2
+  exit 1
+fi
+
+case "$PROG" in
+  ex[0-9][0-9]|ex[0-9][0-9][0-9]) ;;
+  *) echo "PROG deve ser no formato exNN" >&2; exit 1 ;;
+esac
+
+num=$(echo "$PROG" | sed -E 's/ex([0-9]{1,3})/\1/')
+dir="$ROOT_DIR/Ex$(printf "%02d" "$num")_New"
+
+if [ -e "$dir" ]; then
+  echo "Diretório $dir já existe" >&2
+  exit 1
+fi
+
+mkdir -p "$dir"
+
+# criar exNN.c
+cat > "$dir/$PROG.c" <<'C_SRC'
+/* Arquivo template */
+#include <stdio.h>
+
+int soma(int a, int b) {
+    return a + b;
+}
+C_SRC
+
+# criar main.c (com inclusão do arquivo correto)
+cat > "$dir/main.c" <<'MAIN_SRC'
+/* Arquivo template main.c */
+#include "REPLACE_WITH_PROG.c"
+
+int main(void) {
+    printf("Exercício criado\n");
+    return 0;
+}
+MAIN_SRC
+
+# substituir token REPLACE_WITH_PROG pelo nome correto do arquivo
+mv "$dir/main.c" "$dir/main.c.tmp"
+sed "s/REPLACE_WITH_PROG/$PROG/" "$dir/main.c.tmp" > "$dir/main.c"
+rm -f "$dir/main.c.tmp"
+
+chmod 644 "$dir/$PROG.c" "$dir/main.c"
+
+echo "$dir criado"


### PR DESCRIPTION
This PR centralizes builds into bin/, adds cross-platform create-exercise scripts (POSIX + PowerShell), updates .gitignore and README, and includes a CI workflow to smoke-test on Linux and Windows.